### PR TITLE
reinstate miatoll

### DIFF
--- a/v2/devices/miatoll.yml
+++ b/v2/devices/miatoll.yml
@@ -99,18 +99,20 @@ operating_systems:
           - core:user_action:
               action: "bootloader"
       - actions:
+          - fastboot:set_active:
+              slot: "a"
           - fastboot:flash:
               partitions:
-                - partition: "boot"
+                - partition: "boot_a"
                   file: "unpacked_droidian/data/boot.img"
                   group: "firmware"
-                - partition: "dtbo"
+                - partition: "dtbo_a"
                   file: "unpacked_droidian/data/dtbo.img"
                   group: "firmware"
                 - partition: "userdata"
                   file: "unpacked_droidian/data/userdata.img"
                   group: "firmware"
-                - partition: "vbmeta"
+                - partition: "vbmeta_a"
                   file: "unpacked_droidian/data/vbmeta.img"
                   group: "firmware"
                   flags:

--- a/v2/devices/miatoll.yml
+++ b/v2/devices/miatoll.yml
@@ -69,7 +69,8 @@ operating_systems:
           - core:download:
               group: "firmware"
               files:
-                - url: "https://github.com/cutie-shell/droidian/releases/download/nightly/droidian-OFFICIAL_xiaomi_miatoll-arm64-cutie-phone-29.zip"
+                - url: "https://github.com/droidian-images/droidian/releases/download/nightly/droidian-OFFICIAL-phosh-phone-xiaomi_miatoll-api29-arm64-next_20250415.zip"
+
         condition:
           var: "variant"
           value: "cutie"
@@ -86,7 +87,7 @@ operating_systems:
           - core:unpack:
               group: "firmware"
               files:
-                - archive: "droidian-OFFICIAL_xiaomi_miatoll-arm64-cutie-phone-29.zip"
+                - archive: "droidian-OFFICIAL-phosh-phone-xiaomi_miatoll-api29-arm64-next_20250415.zip"
                   dir: "unpacked_droidian"
         condition:
           var: "variant"

--- a/v2/devices/miatoll.yml
+++ b/v2/devices/miatoll.yml
@@ -1,0 +1,120 @@
+name: "Xiaomi Redmi Note 9 Pro/Pro Max/9S - Poco M2 Pro"
+codename: "miatoll"
+aliases:
+  - "joyeuse"
+  - "curtana"
+  - "excalibur"
+  - "gram"
+formfactor: "phone"
+doppelgangers: []
+user_actions:
+  bootloader:
+    title: "Reboot to Bootloader"
+    description: "With the device powered off, hold Volume Down + Power."
+    image: "phone_power_down"
+    button: true
+  confirm_model:
+    title: "Confirm your model"
+    description: "Please double-check that your device is any of the following models: Xiaomi Redmi Note 9 Pro/Pro Max/9S - Poco M2 Pro (joyeuse, excalibur, curtana, gram)."
+  confirm_firmware:
+    title: "Confirm your firmware"
+    description: "Please double-check that your device is running the latest available stock Android 10 firmware."
+    link: "https://devices.droidian.org/#/devices/miatoll#Before_you_proceed"
+  unlock:
+    title: "OEM unlock"
+    description: "If you haven't done so already, make sure to OEM unlock your device first."
+    link: "https://en.miui.com/unlock/"
+  cutie_notice:
+    title: "Cutie Shell: Notice"
+    description: "You selected to install Droidian with Cutie Shell. Cutie Shell is still pre-alpha quality and it is not suitable for production environments. Keep in mind that Cutie Shell is not officially supported or endorsed by Droidian. This edition is maintained directly by Cutie Shell Community Project and you should report any bugs with these images at Cutie Shell Community Project before filing upstream."
+    button: true
+unlock:
+  - "confirm_model"
+  - "confirm_firmware"
+  - "unlock"
+handlers:
+  bootloader_locked:
+    actions:
+      - fastboot:oem_unlock:
+operating_systems:
+  - name: "Droidian"
+    compatible_installer: ">=0.0.1"
+    options:
+      - var: "variant"
+        name: "Variant"
+        tooltip: "The graphical shell to install"
+        type: "select"
+        values:
+          - value: "phosh"
+            label: "Phosh"
+          - value: "cutie"
+            label: "Cutie Shell"
+    prerequisites: []
+    steps:
+      - actions:
+          - core:user_action:
+              action: "cutie_notice"
+        condition:
+          var: "variant"
+          value: "cutie"
+      - actions:
+          - core:download:
+              group: "firmware"
+              files:
+                - url: "https://images.droidian.org/droidian/nightly/arm64/xiaomi/image-fastboot-miatoll.zip"
+        condition:
+          var: "variant"
+          value: "phosh"
+      - actions:
+          - core:download:
+              group: "firmware"
+              files:
+                - url: "https://github.com/cutie-shell/droidian/releases/download/nightly/droidian-OFFICIAL_xiaomi_miatoll-arm64-cutie-phone-29.zip"
+        condition:
+          var: "variant"
+          value: "cutie"
+      - actions:
+          - core:unpack:
+              group: "firmware"
+              files:
+                - archive: "image-fastboot-miatoll.zip"
+                  dir: "unpacked_droidian"
+        condition:
+          var: "variant"
+          value: "phosh"
+      - actions:
+          - core:unpack:
+              group: "firmware"
+              files:
+                - archive: "droidian-OFFICIAL_xiaomi_miatoll-arm64-cutie-phone-29.zip"
+                  dir: "unpacked_droidian"
+        condition:
+          var: "variant"
+          value: "cutie"
+      - actions:
+          - adb:reboot:
+              to_state: "bootloader"
+        fallback:
+          - core:user_action:
+              action: "bootloader"
+      - actions:
+          - fastboot:flash:
+              partitions:
+                - partition: "boot"
+                  file: "unpacked_droidian/data/boot.img"
+                  group: "firmware"
+                - partition: "dtbo"
+                  file: "unpacked_droidian/data/dtbo.img"
+                  group: "firmware"
+                - partition: "userdata"
+                  file: "unpacked_droidian/data/userdata.img"
+                  group: "firmware"
+                - partition: "vbmeta"
+                  file: "unpacked_droidian/data/vbmeta.img"
+                  group: "firmware"
+                  flags:
+                    - "--disable-verity"
+                    - "--disable-verification"
+      - actions:
+          - fastboot:reboot:
+    slideshow: []

--- a/v2/devices/miatoll.yml
+++ b/v2/devices/miatoll.yml
@@ -24,10 +24,6 @@ user_actions:
     title: "OEM unlock"
     description: "If you haven't done so already, make sure to OEM unlock your device first."
     link: "https://en.miui.com/unlock/"
-  cutie_notice:
-    title: "Cutie Shell: Notice"
-    description: "You selected to install Droidian with Cutie Shell. Cutie Shell is still pre-alpha quality and it is not suitable for production environments. Keep in mind that Cutie Shell is not officially supported or endorsed by Droidian. This edition is maintained directly by Cutie Shell Community Project and you should report any bugs with these images at Cutie Shell Community Project before filing upstream."
-    button: true
 unlock:
   - "confirm_model"
   - "confirm_firmware"
@@ -47,16 +43,8 @@ operating_systems:
         values:
           - value: "phosh"
             label: "Phosh"
-          - value: "cutie"
-            label: "Cutie Shell"
     prerequisites: []
     steps:
-      - actions:
-          - core:user_action:
-              action: "cutie_notice"
-        condition:
-          var: "variant"
-          value: "cutie"
       - actions:
           - core:download:
               group: "firmware"
@@ -66,15 +54,6 @@ operating_systems:
           var: "variant"
           value: "phosh"
       - actions:
-          - core:download:
-              group: "firmware"
-              files:
-                - url: "https://github.com/droidian-images/droidian/releases/download/nightly/droidian-OFFICIAL-phosh-phone-xiaomi_miatoll-api29-arm64-next_20250415.zip"
-
-        condition:
-          var: "variant"
-          value: "cutie"
-      - actions:
           - core:unpack:
               group: "firmware"
               files:
@@ -83,15 +62,6 @@ operating_systems:
         condition:
           var: "variant"
           value: "phosh"
-      - actions:
-          - core:unpack:
-              group: "firmware"
-              files:
-                - archive: "droidian-OFFICIAL-phosh-phone-xiaomi_miatoll-api29-arm64-next_20250415.zip"
-                  dir: "unpacked_droidian"
-        condition:
-          var: "variant"
-          value: "cutie"
       - actions:
           - adb:reboot:
               to_state: "bootloader"


### PR DESCRIPTION
This attempts to reinstate miatoll support to the installer.

Marked as WiP because I note that it currently contains no mention of boot_a/b,  dtbo_a/b or vbmeta_a/b,
all of which are mentioned in `flash_all.sh`, so presumably are important.

I have run this against the my RedMi Note 9S, and it did things, looked correct, and when the phone rebooted, it worked, but I suspect that is in part because I'd previously installed the same phone with `flash_all.sh`, which had presumably done things with the AB partitioning, which this yml file then didn't mess up.

I'm happy to restore the stock firmware in order to test that it does a proper job, but first the AB stuff would presumably need to be fixed in the YAML.

Also, I've no idea about cutie -- I guess that bit of the config ought to be removed until someone has chance to test it.